### PR TITLE
Added code to prevent buttons being unloaded

### DIFF
--- a/Sources/Loader.cs
+++ b/Sources/Loader.cs
@@ -298,6 +298,11 @@ namespace TextureReplacer
                 if (texture == null || !texInfo.isReadable)
                     continue;
 
+				// Following line makes sure that buttons aren't unloaded from memory
+                // Needed to allow other mods to manipulate the toolbar buttons (ie: Janitor's Closet
+                if (texture.width <= 38 && texture.height <= 38)
+                    continue;
+
                 // Unload texture from RAM (a.k.a. "make it unreadable") unless set otherwise.
                 if (isUnloadingEnabled.Value && !keepLoaded.Any(r => r.IsMatch(texture.name)))
                 {


### PR DESCRIPTION
Added code to prevent buttons (ie: anything <= 38.38) from being
unloaded. Needed to allow other mods (ie: Janitor's Closet) to
manipulate the toolbar